### PR TITLE
Wrong version reported (1.7.0 should be 1.8.0)

### DIFF
--- a/googletest/configure.ac
+++ b/googletest/configure.ac
@@ -5,7 +5,7 @@ m4_include(m4/acx_pthread.m4)
 # "[1.0.1]"). It also asumes that there won't be any closing parenthesis
 # between "AC_INIT(" and the closing ")" including comments and strings.
 AC_INIT([Google C++ Testing Framework],
-        [1.7.0],
+        [1.8.0],
         [googletestframework@googlegroups.com],
         [gtest])
 


### PR DESCRIPTION
`gtest-config --version` reports wrong version.

Change made against master branch but please note that this affects tag release-1.8.0 and the distribution tarballs.